### PR TITLE
An updated way of printing values (including iterable collections)

### DIFF
--- a/include/cling/Interpreter/RuntimeUniverse.h
+++ b/include/cling/Interpreter/RuntimeUniverse.h
@@ -24,6 +24,7 @@
 #ifdef __cplusplus
 
 #include "cling/Interpreter/RuntimeException.h"
+#include "cling/Interpreter/ToStringConverter.h"
 
 #include <new>
 

--- a/include/cling/Interpreter/ToStringConverter.h
+++ b/include/cling/Interpreter/ToStringConverter.h
@@ -1,0 +1,149 @@
+#ifndef _TOSTRINGCONVERTER_H_
+#define _TOSTRINGCONVERTER_H_
+
+#include <string>
+
+#ifndef _Bool
+#define _Bool bool
+#endif
+
+namespace cling {
+
+  // void pointer
+  std::string printValue(void *ptr);
+
+  // Bool
+  std::string printValue(bool val);
+
+  // Chars
+  std::string printValue(char val);
+
+  std::string printValue(signed char val);
+
+  std::string printValue(unsigned char val);
+
+  // Ints
+  std::string printValue(short val);
+
+  std::string printValue(unsigned short val);
+
+  std::string printValue(int val);
+
+  std::string printValue(unsigned int val);
+
+  std::string printValue(long val);
+
+  std::string printValue(unsigned long val);
+
+  std::string printValue(long long val);
+
+  std::string printValue(unsigned long long val);
+
+  // Reals
+  std::string printValue(float val);
+
+  std::string printValue(double val);
+
+  std::string printValue(long double val);
+
+  // Char pointers
+  std::string printValue(const char *const val);
+
+  std::string printValue(char *val);
+
+  // std::string
+  std::string printValue(const std::string &val);
+
+  // Arrays
+  template<typename T, size_t N>
+  std::string printValue(const T (&obj)[N]) {
+    std::string str = "{ ";
+
+    for(int i = 0; i < N; ++i) {
+      str = str + printValue(obj[i]);
+      if (i < N) str = str + ", ";
+    }
+
+    return str + " }";
+  }
+
+  // Maps declaration
+  template<typename CollectionType>
+  auto printValue_impl(const CollectionType &obj, short)
+      -> decltype(
+          ++(obj.begin()), obj.end(),
+          obj.begin()->first, obj.begin()->second,
+          std::string());
+
+  // Collections like vector, set, deque etc. declaration
+  template<typename CollectionType>
+  auto printValue_impl(const CollectionType &obj, int)
+      -> decltype(
+          ++(obj.begin()), obj.end(),
+          *(obj.begin()),
+          std::string());
+
+  // Fallback for collections declaration
+  template<typename CollectionType>
+  std::string printValue_impl(const CollectionType &obj, long);
+
+  // Collections entry function
+  template<typename CollectionType>
+  auto printValue(const CollectionType &obj)
+  -> decltype(printValue_impl(obj, 0), std::string()) {
+    return printValue_impl(obj, (short)0);  // short -> int -> long = priority order
+  }
+
+  // Maps
+  template<typename CollectionType>
+  auto printValue_impl(const CollectionType &obj, short)
+      -> decltype(
+          ++(obj.begin()), obj.end(),
+          obj.begin()->first, obj.begin()->second,
+          std::string())
+  {
+    std::string str = "{ ";
+
+    auto iter = obj.begin();
+    auto iterEnd = obj.end();
+    while (iter != iterEnd) {
+      str = str + printValue(iter->first);
+      str = str + " => ";
+      str = str + printValue(iter->second);
+      ++iter;
+      if (iter != iterEnd) str = str + ", ";
+    }
+
+    return str + " }";
+  }
+
+  // Collections like vector, set, deque etc.
+  template<typename CollectionType>
+  auto printValue_impl(const CollectionType &obj, int)
+      -> decltype(
+          ++(obj.begin()), obj.end(),
+          *(obj.begin()),
+          std::string())
+  {
+    std::string str = "{ ";
+
+    auto iter = obj.begin();
+    auto iterEnd = obj.end();
+    while (iter != iterEnd) {
+      str = str + printValue(*iter);
+      ++iter;
+      if (iter != iterEnd) str = str + ", ";
+    }
+
+    return str + " }";
+  }
+
+  // Fallback for collections
+  template<typename CollectionType>
+  std::string printValue_impl(const CollectionType &obj, long) {
+    return printValue((void *) &obj);
+  }
+
+}
+
+#endif

--- a/lib/Interpreter/ValuePrinter.cpp
+++ b/lib/Interpreter/ValuePrinter.cpp
@@ -345,6 +345,139 @@ static void StreamValue(llvm::raw_ostream& o, const void* V,
 }
 
 namespace cling {
+
+  std::string printValue(void* ptr) {
+    std::ostringstream strm;
+    if (!ptr) {
+      strm << "<<NULL>>";
+    } else {
+      strm << ptr;
+    }
+    return strm.str();
+  }
+
+  // Bool
+  std::string printValue(const bool val) {
+    std::ostringstream strm;
+    strm << std::boolalpha;
+    strm << val;
+    strm << std::noboolalpha;
+    return strm.str();
+  }
+
+  // Chars
+  std::string printValue(const char val) {
+    std::ostringstream strm;
+    if (val > 0x1F && val < 0x7F) strm << "'" << val << "'";
+    else strm << "0x" << std::hex << (int) val << std::dec;
+    return strm.str();
+  }
+
+  std::string printValue(const signed char val) {
+    return printValue((const char) val);
+  }
+
+  std::string printValue(const unsigned char val) {
+    return printValue((const char) val);
+  }
+
+  // Ints
+  std::string printValue(const short val) {
+    std::ostringstream strm;
+    strm << val;
+    return strm.str();
+  }
+
+  std::string printValue(const unsigned short val) {
+    std::ostringstream strm;
+    strm << val;
+    return strm.str();
+  }
+
+  std::string printValue(const int val) {
+    std::ostringstream strm;
+    strm << val;
+    return strm.str();
+  }
+
+  std::string printValue(const unsigned int val) {
+    std::ostringstream strm;
+    strm << val;
+    return strm.str();
+  }
+
+  std::string printValue(const long val) {
+    std::ostringstream strm;
+    strm << val;
+    return strm.str();
+  }
+
+  std::string printValue(const unsigned long val) {
+    std::ostringstream strm;
+    strm << val;
+    return strm.str();
+  }
+
+  std::string printValue(const long long val) {
+    std::ostringstream strm;
+    strm << val;
+    return strm.str();
+  }
+
+  std::string printValue(const unsigned long long val) {
+    std::ostringstream strm;
+    strm << val;
+    return strm.str();
+  }
+
+  std::string printValue(const float val) {
+    std::ostringstream strm;
+    strm << val;
+    return strm.str();
+  }
+
+  std::string printValue(const double val) {
+    std::ostringstream strm;
+    strm << val;
+    return strm.str();
+  }
+
+  std::string printValue(const long double val) {
+    std::ostringstream strm;
+    strm << val;
+    return strm.str();
+  }
+
+  // Char pointers
+  std::string printValue(const char *const val) {
+    std::ostringstream strm;
+    if (!val) {
+      strm << "<<NULL>>";
+    } else {
+      const char *cobj = val;
+      int i = 0;
+      strm << "\"";
+      while (*cobj != 0) {
+        strm << *cobj;
+        cobj++;
+        i++;
+      }
+      strm << "\"";
+    }
+    return strm.str();
+  }
+
+  std::string printValue(char *val) {
+    return printValue((const char *const) val);
+  }
+
+  // std::string
+  std::string printValue(const std::string & val) {
+    std::ostringstream strm;
+    strm << val;
+    return strm.str();
+  }
+  
 namespace valuePrinterInternal {
   void printValue_Default(llvm::raw_ostream& o, const Value& V) {
     clang::ASTContext& C = V.getASTContext();


### PR DESCRIPTION
An updated way of printing values (including iterable collections) through the invocation of "cling::printValue(T& val)" method in the interpreter.
